### PR TITLE
WATSampleOutlinks: sample translations from `<link rel=alternate hreflang=...>`

### DIFF
--- a/src/org/commoncrawl/examples/mapreduce/WATSampleOutLinks.java
+++ b/src/org/commoncrawl/examples/mapreduce/WATSampleOutLinks.java
@@ -295,6 +295,10 @@ public class WATSampleOutLinks extends Configured implements Tool {
 							case "canonical":
 								break path;
 							case "alternate":
+								if (link.has("hreflang")) {
+									// sample translations
+									break path;
+								}
 								if (extractFeed && link.has("type")) {
 									String type = link.getString("type");
 									if ("application/atom+xml".equals(type)
@@ -303,7 +307,7 @@ public class WATSampleOutLinks extends Configured implements Tool {
 										break path;
 									}
 								}
-								// fall-through for non-feed rel links
+								// fall-through for other rel links
 							default:
 								 // ignore rels not explicitly listed
 								context.getCounter(COUNTER.LINKS_MEDIA_SKIPPED).increment(1);


### PR DESCRIPTION
The sampling of WAT links was conservative in the sense that only links in the HTML body are followed. Links in the header are not because of their technical nature - CSS, Javascript, etc. The only exception was the canonical link.

Sites which do not provide real links to switch to a different language, implementing language switching in less transparent ways (e.g., per Javascript and setting cookies), still may have alternate links to point search engine crawlers to translation pages.

Cf. <https://html.spec.whatwg.org/multipage/links.html#rel-alternate>.